### PR TITLE
Labels: use spaces instead of NULs for trailing padding

### DIFF
--- a/src/DabMux.cpp
+++ b/src/DabMux.cpp
@@ -1909,7 +1909,7 @@ int main(int argc, char *argv[])
                 subchannel =
                     getSubchannel(ensemble->subchannels, (*component)->subchId);
 
-                if ((*component)->label.text()[0] != 0) {
+                if (!((*component)->label.long_label().empty())) {
                     if ((*service)->getType(ensemble) == 0) {   // Programme
                         FIGtype1_4_programme *fig1_4;
                         fig1_4 = (FIGtype1_4_programme*)&etiFrame[index];

--- a/src/MuxElements.h
+++ b/src/MuxElements.h
@@ -61,7 +61,7 @@ class DabLabel
          *          -2 if the short_label is too long
          *          -3 if the text is too long
          */
-        int setLabel(const std::string& text, const std::string& short_label);
+        int setLabel(const std::string& label, const std::string& short_label);
 
         /* Same as above, but sets the flag to 0xff00, truncating at 8
          * characters.
@@ -69,17 +69,20 @@ class DabLabel
          * returns:  0 on success
          *          -3 if the text is too long
          */
-        int setLabel(const std::string& text);
+        int setLabel(const std::string& label);
 
         const char* text() const { return m_text; }
         uint16_t flag() const { return m_flag; }
+        const std::string long_label() const { return m_label; }
         const std::string short_label() const;
 
     private:
-        // In the DAB standard, the label is 16 chars.
-        // We keep it here zero-terminated
-        char m_text[17];
+        // In the DAB standard, the label is 16 bytes long.
+        // We use spaces for padding at the end if needed.
+        char m_text[16];
         uint16_t m_flag;
+        std::string m_label;
+
         int setShortLabel(const std::string& slabel);
 };
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -380,7 +380,8 @@ void printServices(vector<DabService*>& services)
     for (current = services.begin(); current != services.end(); ++current) {
 
         etiLog.level(info) << "Service       " << (*current)->get_rc_name();
-        etiLog.level(info) << " label:       " << (*current)->label.text();
+        etiLog.level(info) << " label:       " <<
+                (*current)->label.long_label();
         etiLog.level(info) << " short label: " <<
                 (*current)->label.short_label();
 
@@ -413,7 +414,8 @@ void printComponent(DabComponent* component)
 {
     etiLog.log(info, " service id:             %i", component->serviceId);
     etiLog.log(info, " subchannel id:          %i", component->subchId);
-    etiLog.log(info, " label:                  %s", component->label.text());
+    etiLog.level(info) << " label:                  " <<
+            component->label.long_label();
     etiLog.level(info) << " short label:            " <<
             component->label.short_label();
 
@@ -531,7 +533,8 @@ void printEnsemble(dabEnsemble* ensemble)
     etiLog.log(info, "Ensemble");
     etiLog.log(info, " id:          0x%lx (%lu)", ensemble->id, ensemble->id);
     etiLog.log(info, " ecc:         0x%x (%u)", ensemble->ecc, ensemble->ecc);
-    etiLog.log(info, " label:       %s", ensemble->label.text());
+    etiLog.level(info) << " label:       " <<
+            ensemble->label.long_label();
     etiLog.level(info) << " short label: " <<
             ensemble->label.short_label();
 


### PR DESCRIPTION
The NULs ATM used for trailing label padding are not defined in the EBU Latin based charset we use. As all 16 label bytes must be used, use spaces instead, like real-world broadcasters do.