### PR TITLE
Reduce FIG0/17 Repetition Rate

### DIFF
--- a/src/fig/FIG0.h
+++ b/src/fig/FIG0.h
@@ -189,7 +189,7 @@ class FIG0_17 : public IFIG
     public:
         FIG0_17(FIGRuntimeInformation* rti);
         virtual FillStatus fill(uint8_t *buf, size_t max_size);
-        virtual FIG_rate repetition_rate(void) { return FIG_rate::A_B; }
+        virtual FIG_rate repetition_rate(void) { return FIG_rate::B; }
 
         virtual const int figtype(void) const { return 0; }
         virtual const int figextension(void) const { return 17; }


### PR DESCRIPTION
A change to FIG0.h to reduce the repetition rate of FIG0/17 to free up FIC space