### PR TITLE
Attempts to create Fifo then open file

### DIFF
--- a/src/dabOutput/dabOutput.h
+++ b/src/dabOutput/dabOutput.h
@@ -154,6 +154,7 @@ class DabOutputFifo : public DabOutputFile
         DabOutputFifo() : DabOutputFile() {}
         ~DabOutputFifo() {}
 
+        int Open(const char* filename);
         int Write(void* buffer, int size);
 
         std::string get_info() const {
@@ -405,4 +406,3 @@ class DabOutputZMQ : public DabOutput
 #endif
 
 #endif
-

--- a/src/dabOutput/dabOutputFifo.cpp
+++ b/src/dabOutput/dabOutputFifo.cpp
@@ -74,10 +74,6 @@ int DabOutputFifo::Open(const char* filename)
     }
 
     this->file_ = mkfifo(filename, 0666);
-    if (this->file_ == -1) {
-        perror(filename);
-        return -2;
-    }
     this->file_ = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0666);
     if (this->file_ == -1) {
         perror(filename);


### PR DESCRIPTION
Copied src/dabOutput/dabOutputFile.cpp : DabOutputFile::Open to 
src/dabOutput/dabOutputFifo.cpp : DabOutputFifo::Open
Added headers to use mkfifo
Added mkfifo before file open
Changed src/dabOutput/dabOutput.h to use DabOutputFifo::Open

**Creates Fifo file as expected**
**Works with stdout and pre-existing files**
