### PR TITLE
Correct insertion of long form SID in FIG0/8

### DIFF
--- a/src/fig/FIG0_8.cpp
+++ b/src/fig/FIG0_8.cpp
@@ -177,8 +177,10 @@ FillStatus FIG0_8::fill(uint8_t *buf, size_t max_size)
             }
 
             if ((*subchannel)->type == subchannel_type_t::Packet) { // Data packet
-                buf[0] = ((*componentFIG0_8)->serviceId >> 8) & 0xFF;
-                buf[1] = ((*componentFIG0_8)->serviceId) & 0xFF;
+                buf[0] = ((*componentFIG0_8)->serviceId >> 24) & 0xFF;
+                buf[1] = ((*componentFIG0_8)->serviceId >> 16) & 0xFF;
+                buf[2] = ((*componentFIG0_8)->serviceId >> 8) & 0xFF;
+                buf[3] = ((*componentFIG0_8)->serviceId) & 0xFF;
                 fig0->Length += 4;
                 buf += 4;
                 remaining -= 4;
@@ -194,8 +196,10 @@ FillStatus FIG0_8::fill(uint8_t *buf, size_t max_size)
                 remaining -= 3;
             }
             else {    // Audio, data stream or FIDC
-                buf[0] = ((*componentFIG0_8)->serviceId >> 8) & 0xFF;
-                buf[1] = ((*componentFIG0_8)->serviceId) & 0xFF;
+                buf[0] = ((*componentFIG0_8)->serviceId >> 24) & 0xFF;
+                buf[1] = ((*componentFIG0_8)->serviceId >> 16) & 0xFF;
+                buf[2] = ((*componentFIG0_8)->serviceId >> 8) & 0xFF;
+                buf[3] = ((*componentFIG0_8)->serviceId) & 0xFF;
                 fig0->Length += 4;
                 buf += 4;
                 remaining -= 4;


### PR DESCRIPTION
Only the bottom 16 bits of long form SIDs (32 bit) were being correctly written into FIG0/8. This amendment corrects that to write all 32bits.