### PR TITLE
FIG 0/9: set default international table ID to 1

### DIFF
--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -368,7 +368,7 @@ static void parse_general(ptree& pt,
         etiLog.level(warn) << "ECC is 0!";
     }
 
-    ensemble->international_table = pt_ensemble.get("international-table", 0);
+    ensemble->international_table = pt_ensemble.get("international-table", 1);
 
     string lto_auto = pt_ensemble.get("local-time-offset", "");
     if (lto_auto == "auto") {


### PR DESCRIPTION
When no value was specified, this field was set to 0. That value however
is reserved, so default to 1 (which most people might want to use).