### PR TITLE
fixed bug DAB with protection level EEP_A 1-4

### DIFF
--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -874,7 +874,12 @@ static void setup_subchannel_from_ptree(shared_ptr<DabSubchannel>& subchan,
     subchan->inputUri = inputUri;
 
     if (type == "dabplus" or type == "audio") {
-        subchan->type = subchannel_type_t::Audio;
+        if(type == "dabplus") {
+            subchan->type = subchannel_type_t::DABPlusAudio;
+        } else {
+            subchan->type = subchannel_type_t::DABAudio;
+        }
+
         subchan->bitrate = 0;
 
         if (proto == "file") {

--- a/src/DabMultiplexer.cpp
+++ b/src/DabMultiplexer.cpp
@@ -273,7 +273,7 @@ void DabMultiplexer::prepare_services_components()
 
             protection = &(*subchannel)->protection;
             switch ((*subchannel)->type) {
-                case subchannel_type_t::Audio:
+                case subchannel_type_t::DABPlusAudio:
                     {
                         if (protection->form == EEP) {
                             /* According to ETSI TS 102 563 Clause 7.1 FIC signalling:
@@ -285,6 +285,15 @@ void DabMultiplexer::prepare_services_components()
                              * 1 1 1 1 1 1."
                              */
                             (*component)->type = 0x3f;
+                        }
+                    }
+                    break;
+                case subchannel_type_t::DABAudio:
+                    {
+                        if (protection->form == EEP) {
+                            /* ASCTy change to 0x0, because DAB mp2 is using
+                             */
+                            (*component)->type = 0x0;
                         }
                     }
                     break;
@@ -720,7 +729,7 @@ void DabMultiplexer::mux_frame(std::vector<std::shared_ptr<DabOutput> >& outputs
         edi_time += chrono::seconds(1);
     }
 
-    /********************************************************************** 
+    /**********************************************************************
      ***********   Section FRPD   *****************************************
      **********************************************************************/
 
@@ -748,7 +757,7 @@ void DabMultiplexer::mux_frame(std::vector<std::shared_ptr<DabOutput> >& outputs
     }
 
 #if HAVE_OUTPUT_EDI
-    /********************************************************************** 
+    /**********************************************************************
      ***********   Finalise and send EDI   ********************************
      **********************************************************************/
 
@@ -817,7 +826,7 @@ void DabMultiplexer::mux_frame(std::vector<std::shared_ptr<DabOutput> >& outputs
 #endif // HAVE_OUTPUT_EDI
 
 #if _DEBUG
-    /********************************************************************** 
+    /**********************************************************************
      ***********   Output a small message *********************************
      **********************************************************************/
     if (currentFrame % 100 == 0) {

--- a/src/MuxElements.cpp
+++ b/src/MuxElements.cpp
@@ -500,7 +500,10 @@ bool DabService::isProgramme(const std::shared_ptr<dabEnsemble>& ensemble) const
 {
     bool ret = false;
     switch (getType(ensemble)) {
-        case subchannel_type_t::Audio: // Audio
+        case subchannel_type_t::DABAudio: // DAB
+            ret = true;
+            break;
+        case subchannel_type_t::DABPlusAudio: // DABPlus
             ret = true;
             break;
         case subchannel_type_t::DataDmb:

--- a/src/MuxElements.h
+++ b/src/MuxElements.h
@@ -58,10 +58,11 @@ class MuxInitException : public std::exception
 
 
 enum class subchannel_type_t {
-    Audio = 0,
-    DataDmb = 1,
-    Fidc = 2,
-    Packet = 3
+    DABAudio = 0,
+    DABPlusAudio = 1,
+    DataDmb = 2,
+    Fidc = 3,
+    Packet = 4
 };
 
 
@@ -297,7 +298,7 @@ public:
             uid(uid),
             input(),
             id(0),
-            type(subchannel_type_t::Audio),
+            type(subchannel_type_t::DABAudio),
             startAddress(0),
             bitrate(0),
             protection()

--- a/src/fig/FIG0_13.cpp
+++ b/src/fig/FIG0_13.cpp
@@ -90,7 +90,7 @@ FillStatus FIG0_13::fill(uint8_t *buf, size_t max_size)
         }
 
         if (    m_transmit_programme &&
-                (*subchannel)->type == subchannel_type_t::Audio &&
+                ((*subchannel)->type == subchannel_type_t::DABPlusAudio || (*subchannel)->type == subchannel_type_t::DABAudio) &&
                 (*componentFIG0_13)->audio.uaType != 0xffff) {
 
             const int required_size = 3+4+11;

--- a/src/fig/FIG0_2.cpp
+++ b/src/fig/FIG0_2.cpp
@@ -161,7 +161,8 @@ FillStatus FIG0_2::fill(uint8_t *buf, size_t max_size)
         etiLog.log(FIG0_2_TRACE, "FIG0_2::fill  loop SId=%04x %s/%s",
                 (*serviceFIG0_2)->id,
                 m_inserting_audio_not_data ? "AUDIO" : "DATA",
-                type == subchannel_type_t::Audio ? "Audio" :
+                type == subchannel_type_t::DABPlusAudio ? "DABPlusAudio" :
+                type == subchannel_type_t::DABAudio ? "DABAudio" :
                 type == subchannel_type_t::Packet ? "Packet" :
                 type == subchannel_type_t::DataDmb ? "DataDmb" :
                 type == subchannel_type_t::Fidc ? "Fidc" : "?");
@@ -202,7 +203,7 @@ FillStatus FIG0_2::fill(uint8_t *buf, size_t max_size)
             break;
         }
 
-        if (type == subchannel_type_t::Audio) {
+        if (type == subchannel_type_t::DABPlusAudio || type == subchannel_type_t::DABAudio) {
             auto fig0_2serviceAudio = (FIGtype0_2_Service*)buf;
 
             fig0_2serviceAudio->SId = htons((*serviceFIG0_2)->id);
@@ -257,7 +258,17 @@ FillStatus FIG0_2::fill(uint8_t *buf, size_t max_size)
             }
 
             switch ((*subchannel)->type) {
-                case subchannel_type_t::Audio:
+                case (subchannel_type_t::DABAudio):
+                    {
+                        auto audio_description = (FIGtype0_2_audio_component*)buf;
+                        audio_description->TMid    = 0;
+                        audio_description->ASCTy   = (*component)->type;
+                        audio_description->SubChId = (*subchannel)->id;
+                        audio_description->PS      = ((curCpnt == 0) ? 1 : 0);
+                        audio_description->CA_flag = 0;
+                    }
+                    break;
+                case (subchannel_type_t::DABPlusAudio):
                     {
                         auto audio_description = (FIGtype0_2_audio_component*)buf;
                         audio_description->TMid    = 0;

--- a/src/fig/FIG0_24.cpp
+++ b/src/fig/FIG0_24.cpp
@@ -93,7 +93,7 @@ FillStatus FIG0_24::fill(uint8_t *buf, size_t max_size)
             }
         }
 
-        subchannel_type_t type = subchannel_type_t::Audio;
+        subchannel_type_t type = subchannel_type_t::DABAudio;
         bool isProgramme = true;
         bool oe = true;
 
@@ -107,7 +107,7 @@ FillStatus FIG0_24::fill(uint8_t *buf, size_t max_size)
                 oe,
                 serviceFIG0_24->service_id,
                 m_inserting_audio_not_data ? "AUDIO" : "DATA",
-                type == subchannel_type_t::Audio ? "Audio" :
+                type == subchannel_type_t::DABAudio ? "Audio" :
                 type == subchannel_type_t::Packet ? "Packet" :
                 type == subchannel_type_t::DataDmb ? "DataDmb" :
                 type == subchannel_type_t::Fidc ? "Fidc" : "?");
@@ -147,7 +147,7 @@ FillStatus FIG0_24::fill(uint8_t *buf, size_t max_size)
             break;
         }
 
-        if (type == subchannel_type_t::Audio) {
+        if (type == subchannel_type_t::DABAudio) {
             auto fig0_2serviceAudio = (FIGtype0_24_audioservice*)buf;
 
             fig0_2serviceAudio->SId = htons(serviceFIG0_24->service_id);

--- a/src/fig/FIG1.cpp
+++ b/src/fig/FIG1.cpp
@@ -90,7 +90,7 @@ FillStatus FIG1_1::fill(uint8_t *buf, size_t max_size)
             break;
         }
 
-        if ((*service)->getType(ensemble) == subchannel_type_t::Audio) {
+        if ((*service)->getType(ensemble) == subchannel_type_t::DABPlusAudio || (*service)->getType(ensemble) == subchannel_type_t::DABAudio) {
             auto fig1_1 = (FIGtype1_1 *)buf;
 
             fig1_1->FIGtypeNumber = 1;
@@ -149,7 +149,7 @@ FillStatus FIG1_4::fill(uint8_t *buf, size_t max_size)
          * a label, which is forbidden since V2.1.1 */
 
         if (not (*component)->label.long_label().empty() ) {
-            if ((*service)->getType(ensemble) == subchannel_type_t::Audio) {
+            if ((*service)->getType(ensemble) == subchannel_type_t::DABPlusAudio || (*service)->getType(ensemble) == subchannel_type_t::DABAudio) {
 
                 if (remaining < 5 + 16 + 2) {
                     break;
@@ -237,7 +237,7 @@ FillStatus FIG1_5::fill(uint8_t *buf, size_t max_size)
             break;
         }
 
-        if ((*service)->getType(ensemble) != subchannel_type_t::Audio) {
+        if ((*service)->getType(ensemble) == subchannel_type_t::DABPlusAudio || (*service)->getType(ensemble) == subchannel_type_t::DABAudio) {
             auto fig1_5 = (FIGtype1_5 *)buf;
             fig1_5->FIGtypeNumber = 1;
             fig1_5->Length = 23;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -329,8 +329,11 @@ void printSubchannels(const vec_sp_subchannel& subchannels)
         etiLog.log(info, " input");
         etiLog.level(info) << "   URI:     " << subchannel->inputUri;
         switch (subchannel->type) {
-            case subchannel_type_t::Audio:
-                etiLog.log(info, " type:       audio");
+            case subchannel_type_t::DABAudio:
+                etiLog.log(info, " type:       DAbAudio");
+                break;
+            case subchannel_type_t::DABPlusAudio:
+                etiLog.log(info, " type:       DABPlusAudio");
                 break;
             case subchannel_type_t::DataDmb:
                 etiLog.log(info, " type:       data");


### PR DESCRIPTION
ETI with DAB (MUSICAM) and EEP_A protection level was not possible. 

see issue: #35 

change:
- add subchannel types:
   - subchannel_type_t::DABPlusAudio
   - subchannel_type_t::DABAudio
- ASCTy is change to 0x0 for DAB Musicam
   - (*component)->type = 0x0;