### PR TITLE
add FIC 0/7

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -108,6 +108,8 @@ odr_dabmux_SOURCES  =src/DabMux.cpp \
 					 src/fig/FIG0_5.h \
 					 src/fig/FIG0_6.cpp \
 					 src/fig/FIG0_6.h \
+                                         src/fig/FIG0_7.cpp \
+                                         src/fig/FIG0_7.h \
 					 src/fig/FIG0_8.cpp \
 					 src/fig/FIG0_8.h \
 					 src/fig/FIG0_9.cpp \

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -3,7 +3,7 @@
    2011, 2012 Her Majesty the Queen in Right of Canada (Communications
    Research Center Canada)
 
-   Copyright (C) 2018
+   Copyright (C) 2020
    Matthias P. Braendli, matthias.braendli@mpb.li
 
     http://www.opendigitalradio.org
@@ -420,6 +420,7 @@ static void parse_general(ptree& pt,
     }
 
     ensemble->international_table = pt_ensemble.get("international-table", 1);
+    ensemble->reconfig_counter = pt_ensemble.get("reconfig-counter", 0);
 
     string lto_auto = pt_ensemble.get("local-time-offset", "");
     if (lto_auto == "auto") {

--- a/src/MuxElements.h
+++ b/src/MuxElements.h
@@ -291,6 +291,7 @@ class dabEnsemble : public RemoteControllable {
         // 1 corresponds to the PTy used in RDS
         // 2 corresponds to program types used in north america
         int international_table = 1;
+        int reconfig_counter = 1;
 
         vec_sp_service services;
         vec_sp_component components;

--- a/src/fig/FIG0_7.cpp
+++ b/src/fig/FIG0_7.cpp
@@ -1,0 +1,74 @@
+/*
+   Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+   2011, 2012 Her Majesty the Queen in Right of Canada (Communications
+   Research Center Canada)
+
+   Copyright (C) 2020
+   Matthias P. Braendli, matthias.braendli@mpb.li
+   Mathias Kuntze, mathias@kuntze.email
+   */
+/*
+   This file is part of ODR-DabMux.
+
+   ODR-DabMux is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   ODR-DabMux is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with ODR-DabMux.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "fig/FIG0structs.h"
+#include "fig/FIG0_7.h"
+#include "utils.h"
+
+namespace FIC {
+
+struct FIGtype0_7 {
+    uint8_t Length:5;
+    uint8_t FIGtypeNumber:3;
+    uint8_t Extension:5;
+    uint8_t PD:1;
+    uint8_t OE:1;
+    uint8_t CN:1;
+
+    uint8_t ReconfigCounter_high:2;
+    uint8_t ServiceCount:6;
+    uint8_t ReconfigCounter_low:8;
+} PACKED;
+
+//=========== FIG 0/0 ===========
+
+FillStatus FIG0_7::fill(uint8_t *buf, size_t max_size)
+{
+    FillStatus fs;
+
+    FIGtype0_7 *fig0_7;
+    fig0_7 = (FIGtype0_7 *)buf;
+
+    fig0_7->FIGtypeNumber = 0;
+    fig0_7->Length = 3;
+    fig0_7->CN = 0;
+    fig0_7->OE = 0;
+    fig0_7->PD = 0;
+    fig0_7->Extension = 7;
+
+    auto ensemble = m_rti->ensemble;
+
+    fig0_7->ServiceCount = ensemble->services.size();
+    fig0_7->ReconfigCounter_high = (ensemble->reconfig_counter % 1024) / 256;
+    fig0_7->ReconfigCounter_low = (ensemble->reconfig_counter % 1024) % 256;
+
+    fs.complete_fig_transmitted = true;
+    fs.num_bytes_written = 4;
+    return fs;
+}
+
+}
+

--- a/src/fig/FIG0_7.h
+++ b/src/fig/FIG0_7.h
@@ -5,6 +5,7 @@
 
    Copyright (C) 2020
    Matthias P. Braendli, matthias.braendli@mpb.li
+   Mathisd Kuntze, mathias@kuntze.email
    */
 /*
    This file is part of ODR-DabMux.
@@ -25,21 +26,26 @@
 
 #pragma once
 
-#include "fig/FIG0structs.h"
-#include "fig/FIG0_0.h"
-#include "fig/FIG0_1.h"
-#include "fig/FIG0_2.h"
-#include "fig/FIG0_3.h"
-#include "fig/FIG0_5.h"
-#include "fig/FIG0_6.h"
-#include "fig/FIG0_7.h"
-#include "fig/FIG0_8.h"
-#include "fig/FIG0_9.h"
-#include "fig/FIG0_10.h"
-#include "fig/FIG0_13.h"
-#include "fig/FIG0_17.h"
-#include "fig/FIG0_18.h"
-#include "fig/FIG0_19.h"
-#include "fig/FIG0_21.h"
-#include "fig/FIG0_24.h"
+#include <cstdint>
+#include <map>
 
+namespace FIC {
+
+// FIG type 0/7, Configuration Info (MCI),
+// Service Number information
+class FIG0_7 : public IFIG
+{
+    public:
+        FIG0_7(FIGRuntimeInformation* rti) :
+            m_rti(rti) {}
+        virtual FillStatus fill(uint8_t *buf, size_t max_size);
+        virtual FIG_rate repetition_rate() const { return FIG_rate::FIG0_0; }
+
+        virtual int figtype() const { return 0; }
+        virtual int figextension() const { return 7; }
+
+    private:
+        FIGRuntimeInformation *m_rti;
+};
+
+}

--- a/src/fig/FIGCarousel.cpp
+++ b/src/fig/FIGCarousel.cpp
@@ -3,7 +3,7 @@
    2011, 2012 Her Majesty the Queen in Right of Canada (Communications
    Research Center Canada)
 
-   Copyright (C) 2017
+   Copyright (C) 2020
    Matthias P. Braendli, matthias.braendli@mpb.li
 
    Implementation of the FIG carousel to schedule the FIGs into the
@@ -82,6 +82,7 @@ FIGCarousel::FIGCarousel(std::shared_ptr<dabEnsemble> ensemble) :
     m_fig0_3(&m_rti),
     m_fig0_5(&m_rti),
     m_fig0_6(&m_rti),
+    m_fig0_7(&m_rti),
     m_fig0_17(&m_rti),
     m_fig0_8(&m_rti),
     m_fig1_0(&m_rti),
@@ -114,6 +115,7 @@ FIGCarousel::FIGCarousel(std::shared_ptr<dabEnsemble> ensemble) :
      * FIG 0/7 have a defined location in the FIC.
      */
     load_and_allocate(m_fig0_0, FIBAllocation::FIB0);
+    load_and_allocate(m_fig0_7, FIBAllocation::FIB0);
     load_and_allocate(m_fig0_1, FIBAllocation::FIB_ANY);
     load_and_allocate(m_fig0_2, FIBAllocation::FIB_ANY);
     load_and_allocate(m_fig0_3, FIBAllocation::FIB_ANY);

--- a/src/fig/FIGCarousel.h
+++ b/src/fig/FIGCarousel.h
@@ -3,7 +3,7 @@
    2011, 2012 Her Majesty the Queen in Right of Canada (Communications
    Research Center Canada)
 
-   Copyright (C) 2017
+   Copyright (C) 2020
    Matthias P. Braendli, matthias.braendli@mpb.li
 
    Implementation of the FIG carousel to schedule the FIGs into the

--- a/src/fig/FIGCarousel.h
+++ b/src/fig/FIGCarousel.h
@@ -98,6 +98,7 @@ class FIGCarousel {
         FIG0_3 m_fig0_3;
         FIG0_5 m_fig0_5;
         FIG0_6 m_fig0_6;
+        FIG0_7 m_fig0_7;
         FIG0_17 m_fig0_17;
         FIG0_8 m_fig0_8;
         FIG1_0 m_fig1_0;


### PR DESCRIPTION
Fixes #42 

- add FIC 0/7 and send with 96ms like FIC 0/0
- reconfiguration counter is changable in mux file with "reconfig-counter" in ensemble part
- tested with several FIG 2 test mux