### PR TITLE
Alarm Cluster 0xFF Handling

### DIFF
--- a/doc/advanced.mux
+++ b/doc/advanced.mux
@@ -134,6 +134,7 @@ services {
             Finance false
 
             ; a comma separated list of clusters in which the service belongs to
+            ; cluster id 255 is not specified here and is ignored (for FIG 0/18)
             clusters "1,2"
         }
     }

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -505,7 +505,7 @@ static void parse_general(ptree& pt,
 
             auto cl = make_shared<AnnouncementCluster>(name);
             cl->cluster_id = hexparse(pt_announcement.get<string>("cluster"));
-            if (cl->cluster_id == 0 or cl->cluster_id == 0xFF) {
+            if (cl->cluster_id == 0) {
                 throw runtime_error("Announcement cluster id " +
                         to_string(cl->cluster_id) + " is not allowed");
             }
@@ -575,13 +575,19 @@ void parse_ptree(
                     continue;
                 }
                 try {
-                    service->clusters.push_back(hexparse(cluster_s));
+                    auto cluster_id = hexparse(cluster_s);
+                    if (cluster_id == 255) {
+                        etiLog.level(warn) << "Announcement cluster id " +
+                                to_string(cluster_id) + " is not allowed and is ignored in FIG 0/18.";
+                        continue;
+                    }
+                    service->clusters.push_back(cluster_id);
                 }
                 catch (const std::exception& e) {
                     etiLog.level(warn) << "Cannot parse '" << clusterlist <<
                         "' announcement clusters for service " << serviceuid <<
                         ": " << e.what();
-                } 
+                }
             }
 
             if (service->ASu != 0 and service->clusters.empty()) {

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -509,6 +509,11 @@ static void parse_general(ptree& pt,
                 throw runtime_error("Announcement cluster id " +
                         to_string(cl->cluster_id) + " is not allowed");
             }
+            if (cl->cluster_id == 255) {
+                etiLog.level(debug) <<
+                    "Alarm flag for FIG 0/0 is set 1, because announcement group with cluster id oxFF is found.";
+                ensemble->alarm_flag = 1;
+            }
             cl->flags = get_announcement_flag_from_ptree(
                     pt_announcement.get_child("flags"));
             cl->subchanneluid = pt_announcement.get<string>("subchannel");

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -193,6 +193,7 @@ static void parse_linkage(ptree& pt,
                     linkageset->id_list.push_back(link);
                 }
             }
+            rcs.enrol(linkageset.get());
             ensemble->linkagesets.push_back(linkageset);
         }
     }
@@ -580,7 +581,7 @@ void parse_ptree(
                     etiLog.level(warn) << "Cannot parse '" << clusterlist <<
                         "' announcement clusters for service " << serviceuid <<
                         ": " << e.what();
-                }
+                } 
             }
 
             if (service->ASu != 0 and service->clusters.empty()) {

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -193,7 +193,6 @@ static void parse_linkage(ptree& pt,
                     linkageset->id_list.push_back(link);
                 }
             }
-            rcs.enrol(linkageset.get());
             ensemble->linkagesets.push_back(linkageset);
         }
     }

--- a/src/MuxElements.cpp
+++ b/src/MuxElements.cpp
@@ -805,22 +805,11 @@ size_t DabSubchannel::readFrame(uint8_t *buffer, size_t size, std::time_t second
     throw logic_error("Unhandled case");
 }
 
-LinkageSet::LinkageSet(const std::string& name,
-        uint16_t lsn,
-        bool active,
-        bool hard,
-        bool international) :
-    lsn(lsn),
-    active(active),
-    hard(hard),
-    international(international),
-    m_name(name)
-{}
 
 
 LinkageSet LinkageSet::filter_type(const ServiceLinkType type)
 {
-    LinkageSet lsd(m_name, lsn, active, hard, international);
+    LinkageSet lsd(m_rc_name, lsn, active, hard, international);
 
     lsd.active = active;
     lsd.keyservice = keyservice;
@@ -832,4 +821,40 @@ LinkageSet LinkageSet::filter_type(const ServiceLinkType type)
     }
 
     return lsd;
+}
+
+
+void LinkageSet::set_parameter(const string& parameter,
+        const string& value)
+{
+    if (parameter == "active") {
+        stringstream ss;
+        ss << value;
+
+        lock_guard<mutex> lock(m_active_mutex);
+        ss >> active;
+    }
+    else {
+        stringstream ss;
+        ss << "Parameter '" << parameter <<
+            "' is not exported by controllable " << get_rc_name();
+        throw ParameterError(ss.str());
+    }
+}
+
+const string LinkageSet::get_parameter(const string& parameter) const
+{
+    using namespace std::chrono;
+
+    stringstream ss;
+    if (parameter == "active") {
+        lock_guard<mutex> lock(m_active_mutex);
+        ss << active;
+    }
+    else {
+        ss << "Parameter '" << parameter <<
+            "' is not exported by controllable " << get_rc_name();
+        throw ParameterError(ss.str());
+    }
+    return ss.str();
 }

--- a/src/MuxElements.cpp
+++ b/src/MuxElements.cpp
@@ -805,11 +805,22 @@ size_t DabSubchannel::readFrame(uint8_t *buffer, size_t size, std::time_t second
     throw logic_error("Unhandled case");
 }
 
+LinkageSet::LinkageSet(const std::string& name,
+        uint16_t lsn,
+        bool active,
+        bool hard,
+        bool international) :
+    lsn(lsn),
+    active(active),
+    hard(hard),
+    international(international),
+    m_name(name)
+{}
 
 
 LinkageSet LinkageSet::filter_type(const ServiceLinkType type)
 {
-    LinkageSet lsd(m_rc_name, lsn, active, hard, international);
+    LinkageSet lsd(m_name, lsn, active, hard, international);
 
     lsd.active = active;
     lsd.keyservice = keyservice;
@@ -821,40 +832,4 @@ LinkageSet LinkageSet::filter_type(const ServiceLinkType type)
     }
 
     return lsd;
-}
-
-
-void LinkageSet::set_parameter(const string& parameter,
-        const string& value)
-{
-    if (parameter == "active") {
-        stringstream ss;
-        ss << value;
-
-        lock_guard<mutex> lock(m_active_mutex);
-        ss >> active;
-    }
-    else {
-        stringstream ss;
-        ss << "Parameter '" << parameter <<
-            "' is not exported by controllable " << get_rc_name();
-        throw ParameterError(ss.str());
-    }
-}
-
-const string LinkageSet::get_parameter(const string& parameter) const
-{
-    using namespace std::chrono;
-
-    stringstream ss;
-    if (parameter == "active") {
-        lock_guard<mutex> lock(m_active_mutex);
-        ss << active;
-    }
-    else {
-        ss << "Parameter '" << parameter <<
-            "' is not exported by controllable " << get_rc_name();
-        throw ParameterError(ss.str());
-    }
-    return ss.str();
 }

--- a/src/MuxElements.h
+++ b/src/MuxElements.h
@@ -546,32 +546,15 @@ struct ServiceLink {
  * TS 103 176 Clause 5.2.3 "Linkage sets". This information will
  * be encoded in FIG 0/6.
  */
-class LinkageSet : public RemoteControllable  {
+class LinkageSet {
     public:
         LinkageSet(const std::string& name,
                 uint16_t lsn,
                 bool active,
                 bool hard,
-                bool international) : 
-            RemoteControllable(name),
-            lsn(lsn),
-            active(active),
-            hard(hard),
-            international(international)
-        {   
-            RC_ADD_PARAMETER(active, "Signal this linkage set active [0 or 1]");
-        }
+                bool international);
 
-        LinkageSet(const LinkageSet& other) :
-            LinkageSet(other.m_rc_name, 
-                       other.lsn, 
-                       other.active, 
-                       other.hard, 
-                       other.international)
-        {   
-        }
-
-        std::string get_name(void) const { return m_rc_name; }
+        std::string get_name(void) const { return m_name; }
 
         std::list<ServiceLink> id_list;
 
@@ -587,22 +570,13 @@ class LinkageSet : public RemoteControllable  {
 
         std::string keyservice; // TODO replace by pointer to service
 
-        //LinkageSet& operator=(const LinkageSet& other) = default;
-
         /* Return a LinkageSet with id_list filtered to include
          * only those links of a given type
          */
         LinkageSet filter_type(const ServiceLinkType type);
 
-                /* Remote control */
-        virtual void set_parameter(const std::string& parameter,
-               const std::string& value);
-
-        /* Getting a parameter always returns a string. */
-        virtual const std::string get_parameter(const std::string& parameter) const;
-
     private:
-        mutable std::mutex m_active_mutex;
+        std::string m_name;
 };
 
 // FIG 0/21

--- a/src/MuxElements.h
+++ b/src/MuxElements.h
@@ -542,15 +542,32 @@ struct ServiceLink {
  * TS 103 176 Clause 5.2.3 "Linkage sets". This information will
  * be encoded in FIG 0/6.
  */
-class LinkageSet {
+class LinkageSet : public RemoteControllable  {
     public:
         LinkageSet(const std::string& name,
                 uint16_t lsn,
                 bool active,
                 bool hard,
-                bool international);
+                bool international) : 
+            RemoteControllable(name),
+            lsn(lsn),
+            active(active),
+            hard(hard),
+            international(international)
+        {   
+            RC_ADD_PARAMETER(active, "Signal this linkage set active [0 or 1]");
+        }
 
-        std::string get_name(void) const { return m_name; }
+        LinkageSet(const LinkageSet& other) :
+            LinkageSet(other.m_rc_name, 
+                       other.lsn, 
+                       other.active, 
+                       other.hard, 
+                       other.international)
+        {   
+        }
+
+        std::string get_name(void) const { return m_rc_name; }
 
         std::list<ServiceLink> id_list;
 
@@ -566,13 +583,22 @@ class LinkageSet {
 
         std::string keyservice; // TODO replace by pointer to service
 
+        //LinkageSet& operator=(const LinkageSet& other) = default;
+
         /* Return a LinkageSet with id_list filtered to include
          * only those links of a given type
          */
         LinkageSet filter_type(const ServiceLinkType type);
 
+                /* Remote control */
+        virtual void set_parameter(const std::string& parameter,
+               const std::string& value);
+
+        /* Getting a parameter always returns a string. */
+        virtual const std::string get_parameter(const std::string& parameter) const;
+
     private:
-        std::string m_name;
+        mutable std::mutex m_active_mutex;
 };
 
 // FIG 0/21

--- a/src/MuxElements.h
+++ b/src/MuxElements.h
@@ -337,6 +337,10 @@ class dabEnsemble : public RemoteControllable {
         static constexpr int RECONFIG_COUNTER_HASH = -2;
         int reconfig_counter = RECONFIG_COUNTER_DISABLED;
 
+        // alarm flag is use for AL flag in FIG 0/0.
+        // set to true if one announcement group with cluster ID 0xFF is available in multiplex file
+        bool alarm_flag = 0;
+
         vec_sp_service services;
         vec_sp_component components;
         vec_sp_subchannel subchannels;

--- a/src/fig/FIG0_0.cpp
+++ b/src/fig/FIG0_0.cpp
@@ -67,7 +67,7 @@ FillStatus FIG0_0::fill(uint8_t *buf, size_t max_size)
 
     fig0_0->EId = htons(m_rti->ensemble->id);
     fig0_0->Change = 0;
-    fig0_0->Al = 0;
+    fig0_0->Al = m_rti->ensemble->alarm_flag;
     fig0_0->CIFcnt_hight = (m_rti->currentFrame / 250) % 20;
     fig0_0->CIFcnt_low = (m_rti->currentFrame % 250);
 


### PR DESCRIPTION
**Alarm Handling**

- cluster id 0xFF is no longer prohibited
- - enables send active alarm with cluster id 0xFF over RC
- filter out the usage of cluster id 0xFF in service (announcement support) -> warning log message
- set AL flag in FIG 0/0 to 1, if cluster with id 0xFF found in mux

**Linking actuator**

- extend LinkageSet with RemoteControllable
- link actuator is now controllable via RC telnet