### PR TITLE
Armv7l

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,10 +54,6 @@ that did not yet make its way into a release, you can clone the
 
        % ./configure
 
-* On a Raspberry Pi and other ARM systems you might need
-
-       % ./configure --with-boost-libdir=/usr/lib/arm-linux-gnueabihf
-
 * Build ODR-DabMux
 
        % make

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -123,6 +123,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are almost assuredly the ones desired.
     AS_CASE([${host_cpu}],
       [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [armv7l],[multiarch_libsubdir="lib/arm-${host_os}"],
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
 


### PR DESCRIPTION
Function **_AX_BOOST_BASE_RUNDETECT** in file m4/ax_boost_base.m4 was changed to add the multi-arch library path for **armv7l**-based debian. For instance, all official Raspi OS armhf images belong to armv7l

By adding the multi-arch path of armv7l (**/usr/lib/arm-linux-gnueabihf**), one no longer needs to use the argument **--with-boost-libdir** when running configure on armv7l. This allows for a simpler and unique build/installation script across different architectures.