### PR TITLE
#include <cstdint> in ReedSolomon.cpp to avoid compilation error under Ubuntu 24.04.3LTS

### DIFF
--- a/lib/ReedSolomon.cpp
+++ b/lib/ReedSolomon.cpp
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <cstdio>
 #include <cstring>         // For memcpy
+#include <cstdint>
 
 extern "C" {
 #include "fec/fec.h"


### PR DESCRIPTION
When compiling lib/ReedSolomon.cpp on Ubuntu 24.04.3LTS, it complains that cstdint is not included.

Issue #82 refers