### PR TITLE
Authentication for EDI connections

### DIFF
--- a/lib/Socket.cpp
+++ b/lib/Socket.cpp
@@ -1164,8 +1164,9 @@ TCPReceiveServer::TCPReceiveServer(size_t blocksize) :
 {
 }
 
-void TCPReceiveServer::start(int listen_port, const std::string& address)
+void TCPReceiveServer::start(int listen_port, const std::string& address, const std::string& auth_key)
 {
+    m_auth_key = auth_key;
     m_listener_socket.listen(listen_port, address);
 
     m_running = true;
@@ -1195,11 +1196,16 @@ void TCPReceiveServer::process()
     constexpr int timeout_ms = 1000;
     constexpr int disconnect_timeout_ms = 10000;
     constexpr int max_num_timeouts = disconnect_timeout_ms / timeout_ms;
-
+    constexpr int auth_timeout_ms = 3000;
+    constexpr size_t auth_max_bytes = 1024 * 1024;  // 1MB to handle client buffering
+    
     while (m_running) {
         auto sock = m_listener_socket.accept(timeout_ms);
 
         int num_timeouts = 0;
+        bool authenticated = m_auth_key.empty(); // If no auth key, consider already authenticated
+        std::vector<uint8_t> auth_buffer;
+        auto auth_start_time = std::chrono::steady_clock::now();
 
         while (m_running and sock.valid()) {
             try {
@@ -1215,7 +1221,82 @@ void TCPReceiveServer::process()
                 }
                 else {
                     buf.resize(r);
-                    m_queue.push(make_shared<TCPReceiveMessageData>(std::move(buf)));
+                    
+                    if (!authenticated) {
+                        // We're in authentication phase
+                        auth_buffer.insert(auth_buffer.end(), buf.begin(), buf.end());
+                        
+                        // Search for AUTH packet anywhere in the buffer
+                        for (size_t i = 0; i + 8 <= auth_buffer.size(); i++) {
+                            // Check for "AUTH" tag at position i
+                            if (auth_buffer[i] == 'A' && auth_buffer[i+1] == 'U' && 
+                                auth_buffer[i+2] == 'T' && auth_buffer[i+3] == 'H') {
+                                
+                                // Read length (big-endian)
+                                uint32_t key_length_bits = (static_cast<uint32_t>(auth_buffer[i+4]) << 24) |
+                                                           (static_cast<uint32_t>(auth_buffer[i+5]) << 16) |
+                                                           (static_cast<uint32_t>(auth_buffer[i+6]) << 8) |
+                                                           static_cast<uint32_t>(auth_buffer[i+7]);
+
+                                uint32_t key_length = key_length_bits / 8;  // Convert bits to bytes
+
+                                // Validate key length
+                                if (key_length > 32 || key_length == 0 || key_length_bits % 8 != 0) {
+                                    fprintf(stderr, "EDI TCP connection rejected: invalid AUTH key length %u\n", key_length);
+                                    sock.close();
+                                    m_queue.push(make_shared<TCPReceiveMessageDisconnected>());
+                                    break;
+                                }
+                                
+                                // Check if we have the complete AUTH packet
+                                if (auth_buffer.size() >= i + 8 + key_length) {
+                                    std::string received_key(auth_buffer.begin() + i + 8, auth_buffer.begin() + i + 8 + key_length);
+                                    
+                                    if (received_key == m_auth_key) {
+                                        fprintf(stderr, "EDI TCP connection authenticated successfully (AUTH found at offset %zu in %zu bytes)\n", 
+                                                i, auth_buffer.size());
+                                        authenticated = true;
+                                        
+                                        // Pass through ALL data unmodified - EDI decoder will handle AUTH tags
+                                        m_queue.push(make_shared<TCPReceiveMessageData>(std::move(auth_buffer)));
+                                        auth_buffer.clear();
+                                    } else {
+                                        fprintf(stderr, "EDI TCP connection rejected: AUTH key mismatch\n");
+                                        sock.close();
+                                        m_queue.push(make_shared<TCPReceiveMessageDisconnected>());
+                                    }
+                                    break;
+                                }
+                                // else: we have AUTH tag but incomplete packet, wait for more data
+                                break;
+                            }
+                        }
+                        
+                        // Only check byte limit if we haven't authenticated yet
+                        if (!authenticated && auth_buffer.size() > auth_max_bytes) {
+                            fprintf(stderr, "EDI TCP connection rejected: exceeded %zu bytes without valid AUTH packet\n", auth_max_bytes);
+                            sock.close();
+                            m_queue.push(make_shared<TCPReceiveMessageDisconnected>());
+                            break;
+                        }
+                        
+                        // Check if we've exceeded time limit
+                        if (!authenticated) {
+                            auto now = std::chrono::steady_clock::now();
+                            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - auth_start_time).count();
+                            if (elapsed > auth_timeout_ms) {
+                                fprintf(stderr, "EDI TCP connection rejected: AUTH timeout after %ldms (received %zu bytes)\n", elapsed, auth_buffer.size());
+                                sock.close();
+                                m_queue.push(make_shared<TCPReceiveMessageDisconnected>());
+                                break;
+                            }
+                        }
+                    } else {
+                        // Already authenticated, pass all data through unmodified
+                        m_queue.push(make_shared<TCPReceiveMessageData>(std::move(buf)));
+                    }
+                    
+                    
                 }
             }
             catch (const TCPSocket::Interrupted&) {

--- a/lib/Socket.h
+++ b/lib/Socket.h
@@ -320,7 +320,7 @@ class TCPReceiveServer {
         TCPReceiveServer(const TCPReceiveServer&) = delete;
         TCPReceiveServer& operator=(const TCPReceiveServer&) = delete;
 
-        void start(int listen_port, const std::string& address);
+        void start(int listen_port, const std::string& address, const std::string& auth_key = "");
 
         // Return an instance of a subclass of TCPReceiveMessage that contains up to blocksize
         // bytes of data, or TCPReceiveMessageEmpty if no data is available.
@@ -330,6 +330,7 @@ class TCPReceiveServer {
         void process();
 
         size_t m_blocksize = 0;
+        std::string m_auth_key = "";
         ThreadsafeQueue<std::shared_ptr<TCPReceiveMessage> > m_queue;
         std::atomic<bool> m_running = ATOMIC_VAR_INIT(false);
         std::string m_exception_data;

--- a/lib/edi/STIDecoder.cpp
+++ b/lib/edi/STIDecoder.cpp
@@ -31,7 +31,8 @@ using namespace std;
 
 STIDecoder::STIDecoder(STIDataCollector& data_collector) :
     m_data_collector(data_collector),
-    m_dispatcher(std::bind(&STIDecoder::packet_completed, this))
+    m_dispatcher(std::bind(&STIDecoder::packet_completed, this)),
+    m_current_packet_has_auth(false)
 {
     using std::placeholders::_1;
     using std::placeholders::_2;
@@ -43,6 +44,8 @@ STIDecoder::STIDecoder(STIDataCollector& data_collector) :
             std::bind(&STIDecoder::decode_ssn, this, _1, _2));
     m_dispatcher.register_tag("*dmy",
             std::bind(&STIDecoder::decode_stardmy, this, _1, _2));
+    m_dispatcher.register_tag("AUTH",
+            std::bind(&STIDecoder::decode_auth, this, _1, _2));
     m_dispatcher.register_tag("ODRa",
             std::bind(&STIDecoder::decode_odraudiolevel, this, _1, _2));
     m_dispatcher.register_tag("ODRv",
@@ -225,6 +228,14 @@ bool STIDecoder::decode_stardmy(const std::vector<uint8_t>&, const tag_name_t&)
     return true;
 }
 
+bool STIDecoder::decode_auth(const std::vector<uint8_t>&, const tag_name_t&)
+{
+    // Silently consume AUTH tags - they are used for TCP connection authentication
+    // and have no relevance to the EDI/STI stream decoding
+    m_current_packet_has_auth = true;
+    return true;
+}
+
 bool STIDecoder::decode_odraudiolevel(const std::vector<uint8_t>& value, const tag_name_t& /*n*/)
 {
     constexpr size_t expected_length = 2 * sizeof(int16_t);
@@ -258,6 +269,12 @@ bool STIDecoder::decode_odrversion(const std::vector<uint8_t>& value, const tag_
 
 void STIDecoder::packet_completed()
 {
+    if (m_current_packet_has_auth) {
+        // Skip assembly for AUTH-only packets
+        m_current_packet_has_auth = false;  // Reset for next packet
+        return;
+    }
+    
     auto seq = m_dispatcher.get_seq_info();
     m_data_collector.assemble(seq);
 }

--- a/lib/edi/STIDecoder.hpp
+++ b/lib/edi/STIDecoder.hpp
@@ -128,7 +128,8 @@ class STIDecoder {
         bool decode_dsti(const std::vector<uint8_t>& value, const tag_name_t& n);
         bool decode_ssn(const std::vector<uint8_t>& value, const tag_name_t& n);
         bool decode_stardmy(const std::vector<uint8_t>& value, const tag_name_t& n);
-
+        bool decode_auth(const std::vector<uint8_t>& value, const tag_name_t& n);
+        
         bool decode_odraudiolevel(const std::vector<uint8_t>& value, const tag_name_t& n);
         bool decode_odrversion(const std::vector<uint8_t>& value, const tag_name_t& n);
 
@@ -136,6 +137,8 @@ class STIDecoder {
 
         STIDataCollector& m_data_collector;
         TagDispatcher m_dispatcher;
+        
+        bool m_current_packet_has_auth = false;
 
         bool m_filter_stream = false;
         uint16_t m_filtered_stream_index = 1;

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -1041,6 +1041,7 @@ static void setup_subchannel_from_ptree(shared_ptr<DabSubchannel>& subchan,
             Inputs::dab_input_edi_config_t config;
             config.buffer_size = pt.get("buffer", config.buffer_size);
             config.prebuffering = pt.get("prebuffering", config.prebuffering);
+            config.ediauthkey = pt.get("ediauthkey", "");
             auto inedi = make_shared<Inputs::Edi>(subchanuid, config);
             rcs.enrol(inedi.get());
             subchan->input = inedi;

--- a/src/input/Edi.cpp
+++ b/src/input/Edi.cpp
@@ -52,6 +52,7 @@ Edi::Edi(const std::string& name, const dab_input_edi_config_t& config) :
     m_sti_decoder(m_sti_writer),
     m_max_frames_overrun(config.buffer_size),
     m_num_frames_prebuffering(config.prebuffering),
+    m_ediauthkey(config.ediauthkey),
     m_name(name),
     m_stats(name)
 {
@@ -135,7 +136,7 @@ void Edi::open(const std::string& name)
         m_input_used = InputUsed::TCP;
         const string addr = m[1].str();
         const int tcp_port = std::stoi(m[2].str());
-        m_tcp_receive_server.start(tcp_port, addr);
+        m_tcp_receive_server.start(tcp_port, addr, m_ediauthkey);
     }
     else {
         throw runtime_error(string("Cannot parse EDI input URI '") + name + "'");

--- a/src/input/Edi.h
+++ b/src/input/Edi.h
@@ -54,6 +54,11 @@ struct dab_input_edi_config_t
      * Same units as buffer_size
      */
     size_t prebuffering = 30;
+    
+    /* Optional authentication key for TCP connections.
+     * If empty, no authentication is required.
+     */
+    std::string ediauthkey = "";
 };
 
 /*
@@ -121,7 +126,9 @@ class Edi : public InputBase, public RemoteControllable {
         /* When not using timestamping, how many frames to prebuffer.
          * Parameter 'prebuffering' inside RC. */
         std::atomic<size_t> m_num_frames_prebuffering = ATOMIC_VAR_INIT(10);
-
+        
+        std::string m_ediauthkey;
+        
         std::string m_name;
         InputStat m_stats;
 };


### PR DESCRIPTION
Supports the EDI authentication with AUTH packets and settings in the config file for each connection - tested and working. Also doesn't pass any data through to the EDI/STI decoder until the AUTH is good, so nonsense hackers won't get very far on AUTH protected sockets