### PR TITLE
Carousel priority2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ cscope.out
 ctags
 tags
 .clang_complete
+*:Zone.Identifier

--- a/src/fig/FIG.h
+++ b/src/fig/FIG.h
@@ -6,6 +6,10 @@
    Copyright (C) 2024
    Matthias P. Braendli, matthias.braendli@mpb.li
 
+   Phase-lock extensions:
+   Copyright (C) 2026
+   Samuel Hunt, Maxxwave Ltd. sam@maxxwave.co.uk
+
    */
 /*
    This file is part of ODR-DabMux.
@@ -51,6 +55,55 @@ class FIGRuntimeInformation {
         unsigned long currentFrame;
         std::shared_ptr<dabEnsemble> ensemble;
         bool factumAnalyzer;
+        
+        /* Phase-lock mechanism for FIG 0/2 and FIG 1/1 synchronisation.
+         *
+         * Problem: Receivers use FIG 0/2 to learn service organisation, then
+         * wait for FIG 1/1 labels for each service. If a receiver completes
+         * its label scan before seeing complete 0/2 data, services may be
+         * missing from the service list.
+         *
+         * Solution: One-way lock - FIG 1/1 cannot send a label until FIG 0/2
+         * has announced that service. FIG 0/2 runs freely at its natural rate
+         * (potentially completing multiple cycles per label cycle).
+         *
+         * Counters are reset when FIG 1/1 starts a new cycle, synchronising
+         * the start of both cycles.
+         *
+         * This ensures that within any label cycle window:
+         * - Every service announced by 0/2 can have its label sent
+         * - 0/2 completes at least once (usually multiple times)
+         * - Receivers see complete service data before labels finish
+         */
+        
+        // Number of programme services announced by FIG 0/2 since last 1/1 cycle start
+        size_t fig0_2_services_announced = 0;
+        
+        // Number of programme service labels sent by FIG 1/1 this cycle  
+        size_t fig1_1_labels_sent = 0;
+        
+        // Called by FIG 0/2 when it sends a programme service entry
+        void on_fig0_2_service_sent() {
+            fig0_2_services_announced++;
+        }
+        
+        // Called by FIG 1/1 to check if it can send a label
+        // Returns true if 0/2 has announced more services than 1/1 has labelled
+        bool can_fig1_1_send() const {
+            return fig1_1_labels_sent < fig0_2_services_announced;
+        }
+        
+        // Called by FIG 1/1 when it sends a service label
+        void on_fig1_1_label_sent() {
+            fig1_1_labels_sent++;
+        }
+        
+        // Called by FIG 1/1 when it starts a new cycle
+        // Resets both counters to synchronise the cycles
+        void on_fig1_1_cycle_start() {
+            fig0_2_services_announced = 0;
+            fig1_1_labels_sent = 0;
+        }
 };
 
 /* Recommended FIG rates according to ETSI TR 101 496-2 Table 3.6.1
@@ -103,4 +156,3 @@ class IFIG
 };
 
 } // namespace FIC
-

--- a/src/fig/FIG0_2.cpp
+++ b/src/fig/FIG0_2.cpp
@@ -5,6 +5,10 @@
 
    Copyright (C) 2016
    Matthias P. Braendli, matthias.braendli@mpb.li
+
+   Phase-lock extensions:
+   Copyright (C) 2026
+   Samuel Hunt, Maxxwave Ltd. sam@maxxwave.co.uk
    */
 /*
    This file is part of ODR-DabMux.
@@ -146,6 +150,7 @@ FillStatus FIG0_2::fill(uint8_t *buf, size_t max_size)
     // Rotate through the subchannels until there is no more
     // space
     for (; serviceFIG0_2 != last_service; ++serviceFIG0_2) {
+        
         const auto type = (*serviceFIG0_2)->getType(ensemble);
         const auto isProgramme = (*serviceFIG0_2)->isProgramme(ensemble);
 
@@ -207,6 +212,9 @@ FillStatus FIG0_2::fill(uint8_t *buf, size_t max_size)
 
             etiLog.log(FIG0_2_TRACE, "FIG0_2::fill  audio SId=%04x",
                (*serviceFIG0_2)->id);
+               
+            // Phase-lock: notify that we've announced a programme service
+            m_rti->on_fig0_2_service_sent();
         }
         else {
             auto fig0_2serviceData = (FIGtype0_2_Service_data*)buf;
@@ -222,6 +230,9 @@ FillStatus FIG0_2::fill(uint8_t *buf, size_t max_size)
 
             etiLog.log(FIG0_2_TRACE, "FIG0_2::fill  data SId=%04x",
                (*serviceFIG0_2)->id);
+            
+            // Note: Data services use FIG 1/5 for labels, not FIG 1/1
+            // So we don't increment the phase-lock counter for data services
         }
 
         int curCpnt = 0;

--- a/src/fig/FIG0_8.cpp
+++ b/src/fig/FIG0_8.cpp
@@ -57,10 +57,14 @@ struct FIGtype0_8_long {
     }
 } PACKED;
 
-FIG0_8::FIG0_8(FIGRuntimeInformation *rti) :
+FIG0_8::FIG0_8(FIGRuntimeInformation *rti, FIG0_8_mode mode) :
     m_rti(rti),
+    m_mode(mode),
     m_initialised(false),
-    m_transmit_programme(false)
+    // In Programme mode the first (and only) pass emits programme components;
+    // in Data mode it emits data components; in Both mode it alternates as the
+    // original implementation did, starting on the data pass.
+    m_transmit_programme(mode == FIG0_8_mode::Programme)
 {
 }
 
@@ -221,13 +225,21 @@ FillStatus FIG0_8::fill(uint8_t *buf, size_t max_size)
     if (componentFIG0_8 == ensemble->components.end()) {
         componentFIG0_8 = ensemble->components.begin();
 
-        // The full database is sent every second full loop
-        fs.complete_fig_transmitted = m_transmit_programme;
-
-        m_transmit_programme = not m_transmit_programme;
-        // Alternate between data and and programme FIG0/13,
-        // do not mix fig0 with PD=0 with extension 13 stuff
-        // that actually needs PD=1, and vice versa
+        if (m_mode == FIG0_8_mode::Both) {
+            // Legacy behaviour: the full database is sent every second full
+            // loop, alternating programme and data passes.
+            fs.complete_fig_transmitted = m_transmit_programme;
+            m_transmit_programme = not m_transmit_programme;
+            // Alternate between data and programme FIG0/8, do not mix fig0
+            // with PD=0 with extension 8 stuff that actually needs PD=1, and
+            // vice versa.
+        }
+        else {
+            // Split mode: this instance carries a single component class, so
+            // one full loop is one complete cycle. m_transmit_programme is
+            // fixed for the lifetime of the instance and is never toggled.
+            fs.complete_fig_transmitted = true;
+        }
     }
 
     fs.num_bytes_written = max_size - remaining;

--- a/src/fig/FIG0_8.h
+++ b/src/fig/FIG0_8.h
@@ -35,18 +35,35 @@ namespace FIC {
 // The Extension 8 of FIG type 0 (FIG 0/8) provides information to link
 // together the service component description that is valid within the ensemble
 // to a service component description that is valid in other ensembles
+// Selects which service components an FIG0_8 instance carries.
+//  - Both:      legacy behaviour, alternates programme then data passes from a
+//               single instance, completing the full database every second loop.
+//  - Programme: carries only programme service components, completing on each loop.
+//  - Data:      carries only data service components, completing on each loop.
+// The split modes let the priority carousel run programme components at rate A
+// (group A MCI, 96ms) and data components at rate B, as permitted by EN 300 401
+// clause 6.1, while keeping each instance single-pass so cycle timing is exact.
+enum class FIG0_8_mode { Both, Programme, Data };
+
 class FIG0_8 : public IFIG
 {
     public:
-        FIG0_8(FIGRuntimeInformation* rti);
+        FIG0_8(FIGRuntimeInformation* rti, FIG0_8_mode mode = FIG0_8_mode::Both);
         virtual FillStatus fill(uint8_t *buf, size_t max_size);
-        virtual FIG_rate repetition_rate() const { return FIG_rate::B; }
+        virtual FIG_rate repetition_rate() const {
+            // Programme-only instances are group A MCI (96ms nominal).
+            // Data-only and legacy Both instances use rate B, matching the
+            // original declaration and EN 300 401 clause 6.1 for data
+            // components.
+            return (m_mode == FIG0_8_mode::Programme) ? FIG_rate::A : FIG_rate::B;
+        }
 
         virtual int figtype() const { return 0; }
         virtual int figextension() const { return 8; }
 
     private:
         FIGRuntimeInformation *m_rti;
+        FIG0_8_mode m_mode;
         bool m_initialised;
         bool m_transmit_programme;
         vec_sp_component::iterator componentFIG0_8;

--- a/src/fig/FIG1.cpp
+++ b/src/fig/FIG1.cpp
@@ -7,6 +7,10 @@
    Matthias P. Braendli, matthias.braendli@mpb.li
 
    Implementation of FIG1
+
+   Phase-lock extensions:
+   Copyright (C) 2026
+   Samuel Hunt, Maxxwave Ltd. sam@maxxwave.co.uk
    */
 /*
    This file is part of ODR-DabMux.
@@ -79,16 +83,18 @@ FillStatus FIG1_1::fill(uint8_t *buf, size_t max_size)
     FillStatus fs;
 
     ssize_t remaining = max_size;
-
-    if (not m_initialised) {
-        service = m_rti->ensemble->services.end();
-        m_initialised = true;
-    }
-
+    
     auto ensemble = m_rti->ensemble;
 
-    // Rotate through the subchannels until there is no more
-    // space
+    if (not m_initialised) {
+        service = ensemble->services.begin();
+        m_initialised = true;
+        // Reset phase-lock counters at start of new cycle
+        // This synchronises 1/1 and 0/2 cycles
+        m_rti->on_fig1_1_cycle_start();
+    }
+
+    // Rotate through the services until there is no more space
     for (; service != ensemble->services.end(); ++service) {
         if (remaining < 4 + 16 + 2) {
             break;
@@ -97,6 +103,13 @@ FillStatus FIG1_1::fill(uint8_t *buf, size_t max_size)
         const bool is_programme = (*service)->isProgramme(ensemble);
 
         if (is_programme and (*service)->label.has_fig1_label()) {
+            // Phase-lock: check if 0/2 has announced enough services
+            // We cannot send a label until 0/2 has announced the service
+            if (!m_rti->can_fig1_1_send()) {
+                // 0/2 hasn't announced enough services yet, wait
+                break;
+            }
+            
             auto fig1_1 = (FIGtype1_1 *)buf;
 
             fig1_1->FIGtypeNumber = 1;
@@ -117,11 +130,15 @@ FillStatus FIG1_1::fill(uint8_t *buf, size_t max_size)
             buf[1] = (*service)->label.flag() & 0xFF;
             buf += 2;
             remaining -= 2;
+            
+            // Phase-lock: notify that we've sent a programme service label
+            m_rti->on_fig1_1_label_sent();
         }
     }
 
     if (service == ensemble->services.end()) {
-        service = ensemble->services.begin();
+        // Cycle complete - mark uninitialised so next call starts fresh
+        m_initialised = false;
         fs.complete_fig_transmitted = true;
     }
 
@@ -278,4 +295,3 @@ FillStatus FIG1_5::fill(uint8_t *buf, size_t max_size)
 }
 
 } // namespace FIC
-

--- a/src/fig/FIGCarouselPriority.cpp
+++ b/src/fig/FIGCarouselPriority.cpp
@@ -601,7 +601,7 @@ size_t FIGCarouselPriority::send_priority_zero(uint8_t* buf, size_t max_size, in
             }
             // Mark cycle complete if the FIG says so
             if (status.complete_fig_transmitted) {
-                entry->on_cycle_complete(status.num_bytes_written > 0);
+                entry->on_cycle_complete();
             }
             if (status.num_bytes_written == 0) {
                 throw std::logic_error("Failed to write FIG 0/0");
@@ -626,9 +626,9 @@ size_t FIGCarouselPriority::send_priority_zero(uint8_t* buf, size_t max_size, in
             if (status.num_bytes_written > 0) {
                 written += status.num_bytes_written;
             }
-            // If complete, reset the cycle - pass whether data was sent
+            // Mark cycle complete if the FIG says so
             if (status.complete_fig_transmitted) {
-                entry->on_cycle_complete(status.num_bytes_written > 0);
+                entry->on_cycle_complete();
 #if PRIORITY_CAROUSEL_DEBUG
                 etiLog.level(info) << "  FIG 0/7: cycle complete, new deadline=" << entry->deadline_ms;
 #endif
@@ -752,9 +752,12 @@ size_t FIGCarouselPriority::try_send_fig(FIGEntryPriority* entry, uint8_t* buf, 
     }
     
     // Handle cycle completion
-    // Pass whether data was actually sent - only record stats if we transmitted something
+    // When complete_fig_transmitted is true, the FIG has completed its full cycle.
+    // For multi-phase FIGs like 0/2 (audio then data), the final phase may write
+    // 0 bytes if there's no data, but the cycle is still complete.
+    // We always record the cycle completion to track end-to-end timing.
     if (status.complete_fig_transmitted) {
-        entry->on_cycle_complete(written > 0);
+        entry->on_cycle_complete();
     }
     
     return written;

--- a/src/fig/FIGCarouselPriority.cpp
+++ b/src/fig/FIGCarouselPriority.cpp
@@ -89,7 +89,8 @@ FIGCarouselPriority::FIGCarouselPriority(
     m_fig0_5(&m_rti),
     m_fig0_6(&m_rti),
     m_fig0_7(&m_rti),
-    m_fig0_8(&m_rti),
+    m_fig0_8_prog(&m_rti, FIG0_8_mode::Programme),
+    m_fig0_8_data(&m_rti, FIG0_8_mode::Data),
     m_fig0_9(&m_rti),
     m_fig0_10(&m_rti),
     m_fig0_13(&m_rti),
@@ -173,6 +174,10 @@ void FIGCarouselPriority::assign_figs_to_priorities()
     // Priority 1: Core MCI (fixed share - ~50% of FIC capacity)
     add_fig_to_priority(m_fig0_1, 1);
     add_fig_to_priority(m_fig0_2, 1);
+    // Programme service component global definitions are group A MCI (96ms
+    // nominal per EN 300 401 clause 6.1) and belong with core MCI. The data
+    // half is carried separately at priority 4 (rate B).
+    add_fig_to_priority(m_fig0_8_prog, 1);
     
     // Priority 2: Service labels (fixed share - critical for scan completion!)
     // WorldDAB: "labels should get 2 FIGs per 96ms frame"
@@ -185,7 +190,7 @@ void FIGCarouselPriority::assign_figs_to_priorities()
     
     // Priority 4: Component details
     add_fig_to_priority(m_fig0_3, 4);  // Packet mode
-    add_fig_to_priority(m_fig0_8, 4);  // Service component global def
+    add_fig_to_priority(m_fig0_8_data, 4);  // Data service component global def (rate B)
     add_fig_to_priority(m_fig0_13, 4); // User applications
     
     // Priority 5: Scaled insertion (should match label cycle time)

--- a/src/fig/FIGCarouselPriority.cpp
+++ b/src/fig/FIGCarouselPriority.cpp
@@ -449,14 +449,35 @@ size_t FIGCarouselPriority::fill_fib(uint8_t* buf, size_t max_size, int fib_inde
                 }
                 tried_this_fib.insert(entry);
                 
-                size_t bytes = try_send_fig(entry, pbuf, remaining);
-                if (bytes > 0) {
+                // A structured FIG (e.g. 0/8) traverses its component list
+                // across successive fills, reporting completion only when the
+                // list wraps. Normally each FIG gets one fill per FIB, which
+                // throttles large FIGs to a few entries per frame. To let such
+                // a FIG use the spare space in this FIB, keep refilling it while
+                // it writes bytes but has not yet completed its cycle. This is
+                // self-limiting: it stops on a completed cycle, a zero-byte
+                // write (no fit / nothing left), or exhausted FIB space, so it
+                // cannot spin. Single-block FIGs complete in one fill and never
+                // loop here.
+                size_t bytes = 0;
+                bool cycle_done = false;
+                bool wrote_any = false;
+                do {
+                    size_t this_bytes = try_send_fig(entry, pbuf, remaining, &cycle_done);
+                    if (this_bytes == 0) {
+                        break;
+                    }
+                    wrote_any = true;
+                    bytes += this_bytes;
+                    written += this_bytes;
+                    remaining -= this_bytes;
+                    pbuf += this_bytes;
+                } while (!cycle_done && remaining > 2);
+
+                if (wrote_any) {
 #if PRIORITY_CAROUSEL_DEBUG
                     fib_log << entry->name() << ":" << bytes << "B ";
 #endif
-                    written += bytes;
-                    remaining -= bytes;
-                    pbuf += bytes;
                     m_priorities[prio].move_to_back(entry);
                     on_fig_sent(prio);
                     made_progress = true;
@@ -735,10 +756,15 @@ void FIGCarouselPriority::decrement_all_counters()
     }
 }
 
-size_t FIGCarouselPriority::try_send_fig(FIGEntryPriority* entry, uint8_t* buf, size_t max_size)
+size_t FIGCarouselPriority::try_send_fig(FIGEntryPriority* entry, uint8_t* buf,
+        size_t max_size, bool* cycle_completed)
 {
     FillStatus status = entry->fig->fill(buf, max_size);
     size_t written = status.num_bytes_written;
+
+    if (cycle_completed) {
+        *cycle_completed = status.complete_fig_transmitted;
+    }
     
     // Validation: FIG should write at least 3 bytes or nothing
     if (written == 1 || written == 2) {

--- a/src/fig/FIGCarouselPriority.h
+++ b/src/fig/FIGCarouselPriority.h
@@ -378,7 +378,8 @@ private:
     FIG0_5 m_fig0_5;
     FIG0_6 m_fig0_6;
     FIG0_7 m_fig0_7;
-    FIG0_8 m_fig0_8;
+    FIG0_8 m_fig0_8_prog;
+    FIG0_8 m_fig0_8_data;
     FIG0_9 m_fig0_9;
     FIG0_10 m_fig0_10;
     FIG0_13 m_fig0_13;

--- a/src/fig/FIGCarouselPriority.h
+++ b/src/fig/FIGCarouselPriority.h
@@ -56,7 +56,7 @@ constexpr int PRIORITY_CRITICAL = 0;
 #define PRIORITY_CAROUSEL_DEBUG 0
 
 // Debug flag for repetition rate statistics - logs actual vs required rates
-#define PRIORITY_RATE_STATS_DEBUG 1
+#define PRIORITY_RATE_STATS_DEBUG 0
 
 /* Helper function to calculate the deadline for the next transmission, in milliseconds.
  * All values are multiples of 24ms (ETI frame duration) for easier reasoning.

--- a/src/fig/FIGCarouselPriority.h
+++ b/src/fig/FIGCarouselPriority.h
@@ -56,7 +56,7 @@ constexpr int PRIORITY_CRITICAL = 0;
 #define PRIORITY_CAROUSEL_DEBUG 0
 
 // Debug flag for repetition rate statistics - logs actual vs required rates
-#define PRIORITY_RATE_STATS_DEBUG 0
+#define PRIORITY_RATE_STATS_DEBUG 1
 
 /* Helper function to calculate the deadline for the next transmission, in milliseconds.
  * All values are multiples of 24ms (ETI frame duration) for easier reasoning.
@@ -190,11 +190,10 @@ struct FIGEntryPriority {
         return false;
     }
     
-    void on_cycle_complete(bool data_was_sent = true) {
-        // Track repetition rate statistics only if data was actually sent
-        // FIGs that return 0 bytes (nothing to send) shouldn't count as "cycles"
-        // as they don't consume bandwidth and skew the statistics
-        if (data_was_sent && last_cycle_complete_ms > 0) {
+    void on_cycle_complete() {
+        // Track repetition rate statistics
+        // Measures end-to-end cycle time (from one completion to the next)
+        if (last_cycle_complete_ms > 0) {
             uint64_t cycle_time = current_time_ms - last_cycle_complete_ms;
             // Only count if meaningful time has passed (avoid artifacts from
             // multiple completions in same frame due to timing granularity)
@@ -205,9 +204,7 @@ struct FIGEntryPriority {
                 if (cycle_time > max_cycle_time_ms) max_cycle_time_ms = cycle_time;
             }
         }
-        if (data_was_sent) {
-            last_cycle_complete_ms = current_time_ms;
-        }
+        last_cycle_complete_ms = current_time_ms;
         
         // Reset deadline for next cycle
         // FIG 0/7 needs extra margin for framephase timing

--- a/src/fig/FIGCarouselPriority.h
+++ b/src/fig/FIGCarouselPriority.h
@@ -344,7 +344,10 @@ private:
     
     // Try to send a FIG, returns bytes written
     // Does NOT move FIG in carousel - caller must do that only if bytes > 0
-    size_t try_send_fig(FIGEntryPriority* entry, uint8_t* buf, size_t max_size);
+    // If cycle_completed is non-null, it is set to whether this fill completed
+    // the FIG's full cycle (used by the multi-entry refill logic).
+    size_t try_send_fig(FIGEntryPriority* entry, uint8_t* buf, size_t max_size,
+            bool* cycle_completed = nullptr);
     
     // Assign FIGs to priority levels (hardcoded assignments)
     void assign_figs_to_priorities();


### PR DESCRIPTION
Two fixes:-

First, bug found in Jaguar Landrover radios which meant on full muxes they seem to use the labels to define the cycle, so one needs to throttle another otherwise on full muxes where potentially you get a race, radios only scan with half the stations then take some time to pick up the rest.

Secondly 0/8 seemed to be going slow on a test full mux with 48 services and lots of adjacent frequency info. Now with 48 services and lots of adjacent frequency info, Everything is circa 250ms average - within the worlddab 288ms maximum and the adjacent frequency is 60 seconds (not 120s as per spec, 60s seems to give better roaming).

I don't feel there is much point in refining any further - it's compliant with a mux that is about as full as concievable (I don't feel anyone will go lower than 24kbps and whilst 16kbps is OK for speech, for every 16kbps speech service I suspect there will be 2x services at 32kbps or more).

Therefore 48 services I feel is the highest we are ever likely to get on a mux. With 31 services on a mux (more typical), it's averaging 180ms repetition rate, 100ms better than the 288ms. It's actually getting better now than Arqiva DAB.